### PR TITLE
Add generic font fallbacks.

### DIFF
--- a/scss/_typography.scss
+++ b/scss/_typography.scss
@@ -14,9 +14,9 @@ h1, h2 {
 }
 
 body, button, input {
-    font-family: 'Source Sans Pro';
+    font-family: 'Source Sans Pro', sans-serif;
 }
 
 pre, textarea {
-    font-family: 'Source Code Pro';
+    font-family: 'Source Code Pro', monospace;
 }


### PR DESCRIPTION
If the intended fonts can't be loaded for some reason, at least we can make sure the text that should be monospace is using *some* kind of monospace.